### PR TITLE
Add channel close functionality and status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,20 @@ A blockchain-powered synchronization tool built on Stacks that enables secure an
 - Post encrypted data updates
 - Verify data integrity using merkle proofs
 - Track sync history on-chain
+- Close channels to prevent further updates
 
 ## Usage
 1. Initialize a sync channel between parties
 2. Post updates to the channel
 3. Verify and retrieve updates
 4. Track sync history
+5. Close channel when synchronization is complete
 
 ## Smart Contract Interface
 ### Functions
 - create-channel: Create a new sync channel
 - post-update: Post an update to a channel
+- close-channel: Close a channel to prevent further updates
 - verify-update: Verify update authenticity 
 - get-channel-history: Get channel update history
 

--- a/tests/aether-sync_test.ts
+++ b/tests/aether-sync_test.ts
@@ -57,3 +57,40 @@ Clarinet.test({
     block.receipts[1].result.expectOk().expectUint(1);
   },
 });
+
+Clarinet.test({
+  name: "Ensure can close channel and prevent further updates",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    const wallet_2 = accounts.get("wallet_2")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "aether-sync",
+        "create-channel",
+        [types.principal(wallet_2.address)],
+        wallet_1.address
+      ),
+      Tx.contractCall(
+        "aether-sync", 
+        "close-channel",
+        [types.uint(1)],
+        wallet_1.address
+      ),
+      Tx.contractCall(
+        "aether-sync",
+        "post-update",
+        [
+          types.uint(1),
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ],
+        wallet_1.address
+      )
+    ]);
+
+    assertEquals(block.receipts.length, 3);
+    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectErr(100);
+  },
+});


### PR DESCRIPTION
This PR adds the ability to close sync channels and prevents further updates to closed channels.

Changes:
- Added new close-channel function that allows channel owner to close a channel
- Added status check in post-update function to prevent updates to closed channels
- Added new error constant for closed channel state
- Added new test case to verify channel closing functionality
- Updated README to document new feature

Impact:
- Channel owners can now formally close channels when synchronization is complete
- Prevents unwanted updates after channel closure
- Improves channel lifecycle management
- All changes are backward compatible

Testing:
- Added new test case verifying channel close functionality
- Existing tests pass without modification
- Manual testing performed for all new functionality